### PR TITLE
fix: resolve context breaking change in expense creation

### DIFF
--- a/next-ui/src/pages/ExpenseEdit.tsx
+++ b/next-ui/src/pages/ExpenseEdit.tsx
@@ -31,7 +31,7 @@ function useQueryParams() {
 
 export function ExpenseEdit() {
 
-    const group = useOutletContext<PartyInfo>();
+    const { party: group } = useOutletContext<{ party: PartyInfo, primaryParticipantId: string | null }>();
     const { expenseId } = useParams();
     const partySettings = usePartySetting(group.id);
 


### PR DESCRIPTION
Updates ExpenseEdit component to use new context structure, preventing crashes when users try to add expenses after the primary participant highlighting changes.