### PR TITLE
refactor: improve primary participant terminology and highlighting

### DIFF
--- a/next-ui/src/controls/SettingsModal.tsx
+++ b/next-ui/src/controls/SettingsModal.tsx
@@ -13,7 +13,7 @@ import {
     SelectItem, 
     Switch
 } from "@heroui/react";
-import { BellIcon, BellRingIcon, CopyIcon, MoonIcon, SettingsIcon, SunIcon, UserIcon, UsersIcon } from "../icons";
+import { BellIcon, BellRingIcon, CopyIcon, MoonIcon, SettingsIcon, SunIcon, UserStarIcon, UsersIcon } from "../icons";
 import { useDarkMode } from "../utils/useDarkMode";
 import { useCallback, useEffect, useState } from "react";
 import { getSubscription, subscribeForIosPush, subscribeForWebPush, unsubscribeWebPush } from "../utils/notification";
@@ -96,7 +96,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                         value={defaultUserName}
                         variant="flat"
                         size="md"
-                        startContent={<UserIcon className="-mb-1 -ml-1 h-7 w-7 text-primary stroke-[1.5px]" />}
+                        startContent={<UserStarIcon className="-mb-1 -ml-1 h-7 w-7 text-primary fill-primary stroke-[1.5px]" />}
                         onChange={(e) => setDefaultUserName(e.target.value)}
                         description={t('headerBar.settings.defaultUser.description')}
                         placeholder={t('headerBar.settings.defaultUser.placeholder')}

--- a/next-ui/src/i18n/locales/de.json
+++ b/next-ui/src/i18n/locales/de.json
@@ -314,7 +314,7 @@
         "descriptionEnabled": "Aktivieren Sie, um über neue oder geänderte Ausgaben in Ihren Gruppen benachrichtigt zu werden."
       },
       "defaultUser": {
-        "label": "Standard-Parteimitgleid",
+        "label": "Hauptteilnehmer",
         "description": "Ihr Name wird automatisch ausgefüllt, wenn Sie neue Gruppen erstellen oder Ausgaben hinzufügen.",
         "placeholder": "Ihr Name"
       },

--- a/next-ui/src/i18n/locales/en.json
+++ b/next-ui/src/i18n/locales/en.json
@@ -313,7 +313,7 @@
         "descriptionEnabled": "Enable to be notified about new or changed expenses in your groups."
       },
       "defaultUser": {
-        "label": "Default participant",
+        "label": "Primary participant",
         "description": "Your name will be automatically filled when creating new groups or adding expenses.",
         "placeholder": "Your name"
       },

--- a/next-ui/src/pages/ExpenseList.tsx
+++ b/next-ui/src/pages/ExpenseList.tsx
@@ -162,8 +162,11 @@ const FullList = ({ group, expenses, lastViewed, isShowReimbursement }:
                                 <span className="text-sm">{expense.isReimbursement ? t('expenseList.labels.to') : t('expenseList.labels.for')} </span>
                                 <span className="text-xs text-dimmed whitespace-normal">
                                     {expense.borrowers.map((b, index) => (
-                                        <span key={b.participantId} className={b.participantId === primaryParticipantId ? 'text-primary' : ''}>
-                                            {b.participantName}{index < expense.borrowers.length - 1 ? ', ' : ''}
+                                        <span key={b.participantId}>
+                                            <span className={b.participantId === primaryParticipantId ? 'text-primary' : ''}>
+                                                {b.participantName}
+                                            </span>
+                                            <>{index < expense.borrowers.length - 1 ? ', ' : ''}</> 
                                         </span>
                                     ))}
                                 </span>


### PR DESCRIPTION
Updates UI terminology from "default participant" to "primary participant" for clarity and enhances visual highlighting of primary participant entries in expense lists to improve user experience.